### PR TITLE
Smooth out home-page appear animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
                       <h1
                         class="position-relative text-color-light font-weight-bold custom-big-text-style-1 text-start text-lg-end pt-4 mt-5 appear-animation"
                         data-appear-animation="fadeInRightShorterPlus"
-                        data-appear-animation-delay="500"
+                        data-appear-animation-delay="300"
                       >
                         <span
                           class="position-absolute bottom-100 left-0 transform3dy-p50 w-100 pt-4 ms-0"
@@ -343,7 +343,7 @@
                       <span
                         class="d-block position-relative z-index-1 pb-5 ps-lg-3 mb-5-5 appear-animation"
                         data-appear-animation="fadeInLeftShorterPlus"
-                        data-appear-animation-delay="1900"
+                        data-appear-animation-delay="800"
                         >河川維持管理</span
                       >
                     </a>
@@ -351,7 +351,7 @@
                       <svg
                         class="svg-fill-color-primary mt-1 appear-animation"
                         data-appear-animation="fadeInLeftShorterPlus"
-                        data-appear-animation-delay="1200"
+                        data-appear-animation-delay="1100"
                         xmlns="http://www.w3.org/2000/svg"
                         xmlns:xlink="http://www.w3.org/1999/xlink"
                         x="0px"
@@ -384,15 +384,15 @@
                       <h2
                         class="position-relative text-color-light font-weight-bold custom-big-text-style-1 custom-big-text-style-1-variation text-center text-lg-end pt-4 mt-5 appear-animation"
                         data-appear-animation="fadeInRightShorterPlus"
-                        data-appear-animation-delay="1000"
+                        data-appear-animation-delay="300"
                       >
                         <span
                           class="d-block position-absolute bottom-100 left-0 transform3dy-p50 w-100 pt-5 ps-5"
                         >
                           <span
                             class="d-inline-flex custom-outline-text-style-1 text-2 text-center appear-animation"
-                            data-appear-animation="fadeInRightShortePlus"
-                            data-appear-animation-delay="2000"
+                            data-appear-animation="fadeInRightShorterPlus"
+                            data-appear-animation-delay="600"
                           >
                             <span class="d-block pt-5">土木工事</span></span
                           >
@@ -411,7 +411,7 @@
                       <span
                         class="d-block line-height-1 position-relative z-index-1 pb-5 ps-lg-3 mb-5-5 appear-animation"
                         data-appear-animation="fadeInLeftShorterPlus"
-                        data-appear-animation-delay="2200"
+                        data-appear-animation-delay="800"
                         >土木工事全般</span
                       >
                     </a>
@@ -419,7 +419,7 @@
                       <svg
                         class="svg-fill-color-dark appear-animation"
                         data-appear-animation="fadeInLeftShorter"
-                        data-appear-animation-delay="1600"
+                        data-appear-animation-delay="1100"
                         xmlns="http://www.w3.org/2000/svg"
                         xmlns:xlink="http://www.w3.org/1999/xlink"
                         x="0px"
@@ -498,14 +498,14 @@
               <h2
                 class="text-color-dark font-weight-bold text-7 line-height-1 mb-3-5 appear-animation"
                 data-appear-animation="fadeInUpShorterPlus"
-                data-appear-animation-delay="2000"
+                data-appear-animation-delay="100"
               >
                 会社紹介
               </h2>
               <p
                 class="text-4 font-weight-light mb-0 appear-animation"
                 data-appear-animation="fadeInUpShorterPlus"
-                data-appear-animation-delay="2200"
+                data-appear-animation-delay="300"
               >
                 皆様の生活になくてはならないもの<br />
                 すなわち、あって当然な物。
@@ -535,7 +535,7 @@
                   y2="12.05"
                   class="appear-animation"
                   data-appear-animation="fadeIn"
-                  data-appear-animation-delay="2400"
+                  data-appear-animation-delay="400"
                   data-appear-animation-duration="100ms"
                 />
                 <line
@@ -548,7 +548,7 @@
                   y2="12.05"
                   class="appear-animation"
                   data-appear-animation="customLineDividerAnim"
-                  data-appear-animation-delay="2400"
+                  data-appear-animation-delay="400"
                   data-appear-animation-duration="2.2s"
                 />
               </svg>
@@ -557,12 +557,12 @@
               <p
                 class="font-weight-medium text-3-5 appear-animation"
                 data-appear-animation="fadeInUpShorterPlus"
-                data-appear-animation-delay="3200"
+                data-appear-animation-delay="500"
               >
                 株式会社TENGUは、自然が豊かに残る札幌市清田区に拠点を置き土木工事、維持工事、調査業務と幅広い業務に携わる事で、法人様、<span
                   class="highlight highlight-primary highlight-bg-opacity highlight-animated"
                   data-appear-animation="highlight-animated-start"
-                  data-appear-animation-delay="3400"
+                  data-appear-animation-delay="1200"
                   data-plugin-options="{'flagClassOnly': true}"
                   >個人様を問わずご満足の頂ける技術を提供しております。</span
                 >
@@ -571,7 +571,7 @@
                 href="company.html"
                 class="custom-view-more d-inline-flex font-weight-medium text-color-primary text-decoration-none appear-animation"
                 data-appear-animation="fadeInUpShorterPlus"
-                data-appear-animation-delay="3400"
+                data-appear-animation-delay="700"
               >
                 会社案内へ
                 <img
@@ -611,7 +611,7 @@
               <div
                 class="col-md-6 mb-5 appear-animation"
                 data-appear-animation="fadeInUpShorterPlus"
-                data-appear-animation-delay="550"
+                data-appear-animation-delay="300"
               >
                 <div class="d-flex">
                   <img
@@ -652,7 +652,7 @@
               <div
                 class="col-md-6 mb-5 appear-animation"
                 data-appear-animation="fadeInUpShorterPlus"
-                data-appear-animation-delay="750"
+                data-appear-animation-delay="450"
               >
                 <div class="d-flex">
                   <img
@@ -693,7 +693,7 @@
               <div
                 class="col-md-6 mb-5 mb-md-0 appear-animation"
                 data-appear-animation="fadeInUpShorterPlus"
-                data-appear-animation-delay="950"
+                data-appear-animation-delay="600"
               >
                 <div class="d-flex">
                   <img
@@ -734,7 +734,7 @@
               <div
                 class="col-md-6 appear-animation"
                 data-appear-animation="fadeInUpShorterPlus"
-                data-appear-animation-delay="1150"
+                data-appear-animation-delay="750"
               >
                 <div class="d-flex">
                   <img
@@ -775,7 +775,7 @@
               <div
                 class="col-md-6 mt-5 appear-animation"
                 data-appear-animation="fadeInUpShorterPlus"
-                data-appear-animation-delay="1150"
+                data-appear-animation-delay="900"
               >
                 <div class="d-flex">
                   <img
@@ -816,7 +816,7 @@
               <div
                 class="col-md-6 mt-5 mr-1 appear-animation"
                 data-appear-animation="fadeInUpShorterPlus"
-                data-appear-animation-delay="1150"
+                data-appear-animation-delay="1050"
               >
                 <div class="d-flex">
                   <img
@@ -857,7 +857,7 @@
               <div
                 class="col-md-6 mt-5 appear-animation"
                 data-appear-animation="fadeInUpShorterPlus"
-                data-appear-animation-delay="1750"
+                data-appear-animation-delay="1200"
               >
                 <div class="d-flex">
                   <img
@@ -901,7 +901,7 @@
             <div
               class="appear-animation"
               data-appear-animation="fadeInRightShorterPlus"
-              data-appear-animation-delay="2200"
+              data-appear-animation-delay="1100"
               data-appear-animation-duration="750ms"
             >
               <div class="custom-square-1 bg-primary mb-5"></div>
@@ -911,7 +911,7 @@
             <div
               class="appear-animation"
               data-appear-animation="fadeInRightShorterPlus"
-              data-appear-animation-delay="1500"
+              data-appear-animation-delay="900"
               data-appear-animation-duration="750ms"
             >
               <div class="custom-square-1 bg-dark pe-5 me-5 mt-4 mb-5"></div>
@@ -1238,8 +1238,8 @@
             <div
               class="appear-animation"
               data-appear-animation="fadeInRightShorterPlus"
-              data-appear-animation-delay="1500"
-              data-appear-animation-duration="1500ms"
+              data-appear-animation-delay="600"
+              data-appear-animation-duration="900ms"
             >
               <div class="custom-square-1 bg-primary mt-0 mb-5"></div>
             </div>


### PR DESCRIPTION
## Summary
- Tightens the hero-section delays and fixes the underline-before-text ordering on both slides
- Fixes the `fadeInRightShortePlus` typo on slide 2 (missing "r") — this animation was silently never firing
- Brings the 会社紹介 section delays down from 2000–3400 ms to 100–1200 ms so the block isn't blank for ~3 s after it scrolls into view
- Evens the 業務案内 card stagger to a clean 150 ms step (300 → 1200) instead of the previous 550/750/950/1150×3/1750
- Shortens the decorative-square delays so they don't finish after the user has scrolled past

## Test plan
- [ ] Hard-refresh `index.html` and confirm the hero title, underline, and department link appear in that visual order, not with the underline first
- [ ] Scroll slowly to the 会社紹介 block; it should become visible within ~1 s of entering the viewport, not after 3 s
- [ ] Scroll to 業務案内 and confirm cards animate in a smooth even stagger
- [ ] Switch hero carousel to slide 2 and confirm the outline text (土木工事) now animates in (it previously did nothing due to the typo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)