### PR TITLE
Modernize blog post and blog index pages

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -231,20 +231,22 @@
       </header>
 
       <div role="main" class="main">
-        <section class="section section-height-3 border-0 m-0">
-          <div class="container position-relative pt-5 pb-5-5 mt-5 mb-5">
-            <div class="row justify-content-end pt-1 mt-lg-5">
+        <section class="section section-height-3 border-0 m-0 blog-hero">
+          <div class="container position-relative pt-5 pb-3 mt-5 mb-2">
+            <div class="row justify-content-end pt-1 mt-lg-3">
               <div class="col-7 col-md-5 position-relative">
-                <ul
-                  class="breadcrumb d-block ps-2 appear-animation"
-                  data-appear-animation="fadeInLeftShorterPlus"
-                  data-appear-animation-delay="200"
-                >
-                  <li><a href="index.html">ホーム</a></li>
-                  <li class="active">ブログ</li>
-                </ul>
+                <div class="blog-breadcrumb-lift">
+                  <ul
+                    class="breadcrumb d-block ps-2 appear-animation"
+                    data-appear-animation="fadeInLeftShorterPlus"
+                    data-appear-animation-delay="200"
+                  >
+                    <li><a href="index.html">ホーム</a></li>
+                    <li class="active">ブログ</li>
+                  </ul>
+                </div>
                 <h1
-                  class="position-absolute top-100 left-0 text-color-light font-weight-bold text-6 line-height-3 text-end mt-5-5"
+                  class="position-absolute top-100 left-0 text-color-light font-weight-bold text-6 line-height-3 text-end mt-3"
                 >
                   <span
                     class="d-block position-relative z-index-1 pb-5 ps-lg-3 appear-animation"
@@ -278,31 +280,20 @@
           </div>
         </section>
 
-        <div class="container mt-5 pt-4 mb-5 mb-lg-4 mb-xl-0 pb-3 pb-xl-0">
-          <div class="row">
-            <div class="col">
-              <h2
-                class="text-color-dark font-weight-bold text-7 line-height-1 mb-3-5 appear-animation"
-                data-appear-animation="fadeInUpShorterPlus"
-                data-appear-animation-delay="200"
-              >
-                ブログ
-              </h2>
-              <p
-                class="text-4 font-weight-light mb-5-5 appear-animation"
-                data-appear-animation="fadeInUpShorterPlus"
-                data-appear-animation-delay="400"
-              >
-                TENGUに関する最新情報
-              </p>
-            </div>
-          </div>
-          <div class="table-responsive">
-            <table class="table table-shikaku">
-              <tbody id="blog-table">
+        <div class="blog-list-bg">
+          <div class="container pt-3 pb-5">
+            <section class="blog-list-card appear-animation"
+              data-appear-animation="fadeInUpShorterPlus"
+              data-appear-animation-delay="200"
+            >
+              <header class="blog-list-header">
+                <h2 class="blog-list-heading">投稿一覧</h2>
+                <p class="blog-list-subtitle">TENGUに関する最新情報</p>
+              </header>
+              <ul class="blog-list" id="blog-list">
                 <!-- Blog posts go here automatically. -->
-              </tbody>
-            </table>
+              </ul>
+            </section>
           </div>
         </div>
       </div>
@@ -316,27 +307,37 @@
         fetch("blog/posts.json")
           .then((response) => response.json())
           .then((posts) => {
-            let blogTable = document.getElementById("blog-table");
-            blogTable.innerHTML = "";
+            const list = document.getElementById("blog-list");
+            list.innerHTML = "";
 
             posts.sort((a, b) => new Date(b.date) - new Date(a.date));
 
             posts.forEach((post) => {
-              let row = document.createElement("tr");
-              row.classList.add("mb-5");
+              const li = document.createElement("li");
+              li.className = "blog-list-item";
 
-              let dateCell = document.createElement("td");
-              dateCell.classList.add("text-4-5", "font-weight-light", "mb-3");
-              dateCell.textContent = post.date;
+              const link = document.createElement("a");
+              link.className = "blog-list-link";
+              link.href = `blog_post.html?id=${post.id}`;
 
-              let titleCell = document.createElement("td");
-              titleCell.classList.add("text-4-5", "font-weight-light", "mb-3");
+              const date = document.createElement("span");
+              date.className = "blog-list-date";
+              date.textContent = post.date;
 
-              titleCell.innerHTML = `<a href="blog_post.html?id=${post.id}">${post.title}</a>`;
+              const title = document.createElement("span");
+              title.className = "blog-list-title";
+              title.textContent = post.title;
 
-              row.appendChild(dateCell);
-              row.appendChild(titleCell);
-              blogTable.appendChild(row);
+              const arrow = document.createElement("span");
+              arrow.className = "blog-list-arrow";
+              arrow.setAttribute("aria-hidden", "true");
+              arrow.textContent = "→";
+
+              link.appendChild(date);
+              link.appendChild(title);
+              link.appendChild(arrow);
+              li.appendChild(link);
+              list.appendChild(li);
             });
           })
           .catch((error) => console.error("Error loading blog:", error));
@@ -376,4 +377,150 @@
     type="text/javascript"
     src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js"
   ></script>
+  <style>
+    .blog-hero.section-height-3 {
+      min-height: 240px !important;
+    }
+
+    .blog-breadcrumb-lift {
+      transform: translateY(-1rem);
+    }
+
+    .blog-hero .breadcrumb {
+      margin-bottom: 0;
+    }
+
+    @media (max-width: 991.98px) {
+      .blog-hero > .container {
+        margin-top: 2.5rem !important;
+        padding-top: 2rem !important;
+      }
+    }
+
+    .blog-list-bg {
+      background:
+        radial-gradient(1200px 400px at 50% -100px, #f1ede5 0%, rgba(241, 237, 229, 0) 70%),
+        #f7f5f1;
+      padding: 0.75rem 0 3rem;
+    }
+
+    .blog-list-bg > .container {
+      max-width: 1080px;
+    }
+
+    .blog-list-card {
+      max-width: 1040px;
+      margin: 0 auto;
+      background: #ffffff;
+      border-radius: 14px;
+      padding: clamp(1.75rem, 1rem + 2vw, 2.75rem) clamp(1.5rem, 0.75rem + 2.5vw, 3.5rem);
+      box-shadow:
+        0 1px 2px rgba(17, 24, 39, 0.04),
+        0 8px 24px rgba(17, 24, 39, 0.05);
+    }
+
+    .blog-list-header {
+      margin: 0 0 1.5rem;
+    }
+
+    .blog-list-heading {
+      color: #111827;
+      font-weight: 700;
+      font-size: clamp(1.4rem, 0.9rem + 1.5vw, 1.85rem);
+      line-height: 1.35;
+      margin: 0 0 0.4rem;
+    }
+
+    .blog-list-subtitle {
+      color: #6b7280;
+      font-size: 0.98rem;
+      margin: 0;
+    }
+
+    .blog-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      border-top: 1px solid #ececec;
+    }
+
+    .blog-list-item {
+      border-bottom: 1px solid #ececec;
+    }
+
+    .blog-list-link {
+      display: grid;
+      grid-template-columns: 7.5rem 1fr auto;
+      gap: 1.25rem;
+      align-items: center;
+      padding: 1.1rem 0.75rem;
+      text-decoration: none;
+      color: inherit;
+      border-radius: 8px;
+      transition: background 150ms ease;
+    }
+
+    .blog-list-link:hover,
+    .blog-list-link:focus-visible {
+      background: #faf8f4;
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .blog-list-date {
+      color: #9ca3af;
+      font-size: 0.92rem;
+      font-weight: 500;
+      font-variant-numeric: tabular-nums;
+      letter-spacing: 0.01em;
+    }
+
+    .blog-list-title {
+      color: #1f2937;
+      font-size: 1rem;
+      font-weight: 600;
+      line-height: 1.55;
+    }
+
+    .blog-list-link:hover .blog-list-title,
+    .blog-list-link:focus-visible .blog-list-title {
+      color: #111827;
+    }
+
+    .blog-list-arrow {
+      color: #c79b54;
+      font-size: 1rem;
+      font-weight: 600;
+      opacity: 0;
+      transform: translateX(-4px);
+      transition: opacity 150ms ease, transform 150ms ease;
+    }
+
+    .blog-list-link:hover .blog-list-arrow,
+    .blog-list-link:focus-visible .blog-list-arrow {
+      opacity: 1;
+      transform: translateX(0);
+    }
+
+    @media (max-width: 575px) {
+      .blog-list-bg {
+        padding: 0 0 2.5rem;
+      }
+
+      .blog-list-card {
+        padding: 1.5rem 1.25rem;
+        border-radius: 10px;
+      }
+
+      .blog-list-link {
+        grid-template-columns: 1fr;
+        gap: 0.25rem;
+        padding: 1rem 0.25rem;
+      }
+
+      .blog-list-arrow {
+        display: none;
+      }
+    }
+  </style>
 </html>

--- a/blog_post.html
+++ b/blog_post.html
@@ -231,20 +231,22 @@
       </header>
 
       <div role="main" class="main">
-        <section class="section section-height-3 border-0 m-0">
-          <div class="container position-relative pt-5 pb-5-5 mt-5 mb-5">
-            <div class="row justify-content-end pt-1 mt-lg-5">
+        <section class="section section-height-3 border-0 m-0 blog-hero">
+          <div class="container position-relative pt-5 pb-3 mt-5 mb-2">
+            <div class="row justify-content-end pt-1 mt-lg-3">
               <div class="col-7 col-md-5 position-relative">
-                <ul
-                  class="breadcrumb d-block ps-2 appear-animation"
-                  data-appear-animation="fadeInLeftShorterPlus"
-                  data-appear-animation-delay="200"
-                >
-                  <li><a href="index.html">ホーム</a></li>
-                  <li class="active">ブログ</li>
-                </ul>
+                <div class="blog-breadcrumb-lift">
+                  <ul
+                    class="breadcrumb d-block ps-2 appear-animation"
+                    data-appear-animation="fadeInLeftShorterPlus"
+                    data-appear-animation-delay="200"
+                  >
+                    <li><a href="index.html">ホーム</a></li>
+                    <li class="active">ブログ</li>
+                  </ul>
+                </div>
                 <h1
-                  class="position-absolute top-100 left-0 text-color-light font-weight-bold text-6 line-height-3 text-end mt-5-5"
+                  class="position-absolute top-100 left-0 text-color-light font-weight-bold text-6 line-height-3 text-end mt-3"
                 >
                   <span
                     class="d-block position-relative z-index-1 pb-5 ps-lg-3 appear-animation"
@@ -279,7 +281,7 @@
         </section>
 
         <div class="blog-post-bg">
-          <div class="container pt-4 pb-5 mt-2">
+          <div class="container pt-3 pb-5">
             <div class="row">
               <div
                 class="col-lg-12 order-lg-2 mt-0 appear-animation"
@@ -561,19 +563,47 @@
     src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js"
   ></script>
   <style>
+    .blog-hero.section-height-3 {
+      min-height: 240px !important;
+    }
+
+    .blog-breadcrumb-lift {
+      transform: translateY(-1rem);
+    }
+
+    @media (max-width: 991.98px) {
+      .blog-hero > .container {
+        margin-top: 2.5rem !important;
+        padding-top: 2rem !important;
+      }
+    }
+
+
+    .blog-hero .breadcrumb {
+      margin-bottom: 0;
+    }
+
     .blog-post-bg {
       background:
         radial-gradient(1200px 400px at 50% -100px, #f1ede5 0%, rgba(241, 237, 229, 0) 70%),
         #f7f5f1;
-      padding: 2rem 0 3.5rem;
+      padding: 0.75rem 0 3rem;
+    }
+
+    .blog-post-bg > .container {
+      max-width: 1080px;
+    }
+
+    .blog-post-bg .row.mb-4 {
+      margin-bottom: 1rem !important;
     }
 
     .blog-article {
-      max-width: 820px;
+      max-width: 1040px;
       margin: 0 auto;
       background: #ffffff;
       border-radius: 14px;
-      padding: clamp(1.75rem, 1rem + 2vw, 3rem) clamp(1.25rem, 0.5rem + 2.5vw, 3rem);
+      padding: clamp(1.75rem, 1rem + 2vw, 2.75rem) clamp(1.5rem, 0.75rem + 2.5vw, 3.5rem);
       box-shadow:
         0 1px 2px rgba(17, 24, 39, 0.04),
         0 8px 24px rgba(17, 24, 39, 0.05);

--- a/blog_post.html
+++ b/blog_post.html
@@ -302,32 +302,7 @@
                     class="text-color-dark font-weight-bold text-7 line-height-1 mb-4 mt-2 text-center" id="blog-title"
                   ></h2>
           
-                  <table class="table table-bordered table-hover shadow-sm">
-                    <thead class="bg-light">
-                      <tr>
-                        <th class="px-5 text-center">項目</th>
-                        <th class="text-center">詳細</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <th class="bg-light">日時：</th>
-                        <td class="fw-bold" id="blog-date"></td>
-                      </tr>
-                      <tr>
-                        <th class="bg-light">会場：</th>
-                        <td class="fw-bold" id="blog-location"></td>
-                      </tr>
-                      <tr>
-                        <th class="bg-light">住所：</th>
-                        <td class="fw-bold" id="blog-address"></td>
-                      </tr>
-                      <tr>
-                        <th class="bg-light">参加者：</th>
-                        <td class="fw-bold" id="blog-participants"></td>
-                      </tr>
-                    </tbody>
-                  </table>
+                  <dl id="blog-meta" class="blog-meta"></dl>
           
                   <div class="row mt-4" id="blog-images"></div>
                 </div>
@@ -403,25 +378,17 @@
                 </div>`;
                 }
                 
-                // Replace the table with the article content
-                const tableElement = contentContainer.querySelector("table.table");
-                if (tableElement) {
-                // Create a container for the article content
+                const metaElement = contentContainer.querySelector("#blog-meta");
+                if (metaElement) {
                 const articleContainer = document.createElement("div");
                 articleContainer.className = "article-container";
                 articleContainer.innerHTML = articleHTML;
-                
-                // Replace table with article content
-                tableElement.parentNode.replaceChild(articleContainer, tableElement);
+                metaElement.parentNode.replaceChild(articleContainer, metaElement);
                 }
             } else {
-                // Event layout: Table with details
-                const tableBody = document.querySelector("table.table tbody");
-                
-                // Clear existing table rows
-                tableBody.innerHTML = "";
-                
-                // Define the fields to display in the table and their labels
+                const metaList = document.getElementById("blog-meta");
+                metaList.innerHTML = "";
+
                 const tableFields = [
                 { key: "date", label: "日時" },
                 { key: "location", label: "会場" },
@@ -429,12 +396,9 @@
                 { key: "participants", label: post.participantsLabel || "参加者" },
                 { key: "activity", label: "活動" }
                 ];
-                
-                // Create table rows dynamically based on available data
+
                 tableFields.forEach(field => {
-                // Only create the row if the data exists
                 if (post[field.key]) {
-                    // Special case for date and day_time
                     let value = post[field.key];
                     if (field.key === "date") {
                     value = post.displayDate || post.date;
@@ -442,13 +406,15 @@
                         value = `${post.date} ${post.day_time}`;
                     }
                     }
-                    
-                    const row = document.createElement("tr");
-                    row.innerHTML = `
-                    <th class="bg-light">${field.label}：</th>
-                    <td class="fw-bold">${value}</td>
-                    `;
-                    tableBody.appendChild(row);
+
+                    const dt = document.createElement("dt");
+                    dt.className = "blog-meta-label";
+                    dt.textContent = field.label;
+                    const dd = document.createElement("dd");
+                    dd.className = "blog-meta-value";
+                    dd.textContent = value;
+                    metaList.appendChild(dt);
+                    metaList.appendChild(dd);
                 }
                 });
             }
@@ -601,20 +567,61 @@
     src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js"
   ></script>
   <style>
-    #blog-title-container table {
-      width: 100%;
-      table-layout: fixed !important;
+    .blog-meta {
+      display: grid;
+      grid-template-columns: 7rem 1fr;
+      column-gap: 1.75rem;
+      row-gap: 0;
+      margin: 0 0 2rem;
+      padding: 0.5rem 1.75rem;
+      background: #fafafa;
+      border-radius: 10px;
     }
 
-    #blog-title-container table th:first-child,
-    #blog-title-container table td:first-child {
-      width: 120px !important;
-      white-space: nowrap;
+    .blog-meta dt,
+    .blog-meta dd {
+      margin: 0;
+      padding: 0.85rem 0;
+      border-bottom: 1px solid #ececec;
+      font-size: 0.98rem;
+      line-height: 1.5;
     }
 
-    #blog-title-container table th:nth-child(2),
-    #blog-title-container table td:nth-child(2) {
-      width: auto !important;
+    .blog-meta dt {
+      color: #6b7280;
+      font-weight: 500;
+      letter-spacing: 0.02em;
+    }
+
+    .blog-meta dd {
+      color: #1f2937;
+      font-weight: 600;
+    }
+
+    .blog-meta dt:last-of-type,
+    .blog-meta dd:last-of-type {
+      border-bottom: none;
+    }
+
+    @media (max-width: 575px) {
+      .blog-meta {
+        grid-template-columns: 1fr;
+        padding: 0.75rem 1.25rem;
+      }
+
+      .blog-meta dt {
+        padding: 0.85rem 0 0.1rem;
+        border-bottom: none;
+        font-size: 0.85rem;
+      }
+
+      .blog-meta dd {
+        padding: 0 0 0.85rem;
+      }
+
+      .blog-meta dt:last-of-type {
+        /* keep zero bottom-border behavior */
+      }
     }
 
     /* Image caption styling */

--- a/blog_post.html
+++ b/blog_post.html
@@ -278,7 +278,8 @@
           </div>
         </section>
 
-        <div class="container mt-4">
+        <div class="blog-post-bg">
+          <div class="container pt-4 pb-5 mt-2">
             <div class="row">
               <div
                 class="col-lg-12 order-lg-2 mt-0 appear-animation"
@@ -302,18 +303,13 @@
 
                   <div id="blog-meta" class="blog-meta"></div>
 
-                  <div class="row blog-images" id="blog-images"></div>
-
                   <div class="blog-description-wrapper">
                     <div id="blog-description" class="blog-description"></div>
                   </div>
+
+                  <div class="row blog-images" id="blog-images"></div>
                 </article>
               </div>
-            </div>
-          
-
-            <div class="col-lg-4 order-lg-1 position-relative">
-              <!--  -->
             </div>
           </div>
         </div>
@@ -565,9 +561,22 @@
     src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js"
   ></script>
   <style>
+    .blog-post-bg {
+      background:
+        radial-gradient(1200px 400px at 50% -100px, #f1ede5 0%, rgba(241, 237, 229, 0) 70%),
+        #f7f5f1;
+      padding: 2rem 0 3.5rem;
+    }
+
     .blog-article {
       max-width: 820px;
       margin: 0 auto;
+      background: #ffffff;
+      border-radius: 14px;
+      padding: clamp(1.75rem, 1rem + 2vw, 3rem) clamp(1.25rem, 0.5rem + 2.5vw, 3rem);
+      box-shadow:
+        0 1px 2px rgba(17, 24, 39, 0.04),
+        0 8px 24px rgba(17, 24, 39, 0.05);
     }
 
     .blog-article-title {
@@ -611,16 +620,16 @@
       word-break: break-word;
     }
 
+    .blog-description-wrapper {
+      margin: 0 0 2.5rem;
+    }
+
     .blog-images {
-      margin: 0 -0.75rem 2.5rem;
+      margin: 0 -0.75rem;
     }
 
     .blog-image {
       border-radius: 6px;
-    }
-
-    .blog-description-wrapper {
-      margin-top: 1rem;
     }
 
     .blog-description {
@@ -648,8 +657,13 @@
     }
 
     @media (max-width: 575px) {
+      .blog-post-bg {
+        padding: 1.5rem 0 2.5rem;
+      }
+
       .blog-article {
-        padding: 0 0.25rem;
+        padding: 1.5rem 1.25rem;
+        border-radius: 10px;
       }
 
       .blog-meta {

--- a/blog_post.html
+++ b/blog_post.html
@@ -297,20 +297,17 @@
                     </a>
                   </div>
                 </div>
-                <div id="blog-title-container" class="row">
-                  <h2
-                    class="text-color-dark font-weight-bold text-7 line-height-1 mb-4 mt-2 text-center" id="blog-title"
-                  ></h2>
-          
-                  <dl id="blog-meta" class="blog-meta"></dl>
-          
-                  <div class="row mt-4" id="blog-images"></div>
-                </div>
-          
-                <!-- Stylized Bottom Text -->
-                <div class="p-4 mt-4 bg-light text-dark rounded shadow-sm">
-                    <div class="text-5" id="blog-description"></div>
-                </div>
+                <article id="blog-title-container" class="blog-article">
+                  <h2 id="blog-title" class="blog-article-title"></h2>
+
+                  <div id="blog-meta" class="blog-meta"></div>
+
+                  <div class="row blog-images" id="blog-images"></div>
+
+                  <div class="blog-description-wrapper">
+                    <div id="blog-description" class="blog-description"></div>
+                  </div>
+                </article>
               </div>
             </div>
           
@@ -407,27 +404,29 @@
                     }
                     }
 
-                    const dt = document.createElement("dt");
-                    dt.className = "blog-meta-label";
-                    dt.textContent = field.label;
-                    const dd = document.createElement("dd");
-                    dd.className = "blog-meta-value";
-                    dd.textContent = value;
-                    metaList.appendChild(dt);
-                    metaList.appendChild(dd);
+                    const item = document.createElement("div");
+                    item.className = "blog-meta-item";
+                    const label = document.createElement("span");
+                    label.className = "blog-meta-label";
+                    label.textContent = field.label;
+                    const val = document.createElement("span");
+                    val.className = "blog-meta-value";
+                    val.textContent = value;
+                    item.appendChild(label);
+                    item.appendChild(val);
+                    metaList.appendChild(item);
                 }
                 });
             }
             
-            // Set the description if available
             const descriptionElement = document.getElementById("blog-description");
+            const descriptionWrapper = descriptionElement ? descriptionElement.closest(".blog-description-wrapper") : null;
             if (descriptionElement) {
                 if (post.description) {
                 descriptionElement.innerHTML = post.description;
-                descriptionElement.parentElement.style.display = "block";
-                } else {
-                // Hide the description container if there's no description
-                descriptionElement.parentElement.style.display = "none";
+                if (descriptionWrapper) descriptionWrapper.style.display = "block";
+                } else if (descriptionWrapper) {
+                descriptionWrapper.style.display = "none";
                 }
             }
 
@@ -444,8 +443,8 @@
                 const imgElement = document.createElement("img");
                 imgElement.src = image;
                 imgElement.alt = `Blog Image ${index + 1}`;
-                imgElement.className = "img-fluid rounded shadow-lg d-block mx-auto";
-                
+                imgElement.className = "img-fluid rounded d-block mx-auto blog-image";
+
                 imgElement.style.maxWidth = "100%";
                 imgElement.style.height = "auto";
                 
@@ -513,9 +512,8 @@
             const newImage = new Image();
             newImage.src = path + '?nocache=' + new Date().getTime();
             newImage.alt = `Blog Image ${index + 1}`;
-            newImage.className = 'img-fluid rounded shadow-lg d-block mx-auto';
+            newImage.className = 'img-fluid rounded d-block mx-auto blog-image';
             newImage.style.maxWidth = '100%';
-            newImage.style.border = '2px solid green';
             
             col.appendChild(newImage);
             
@@ -567,60 +565,101 @@
     src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js"
   ></script>
   <style>
+    .blog-article {
+      max-width: 820px;
+      margin: 0 auto;
+    }
+
+    .blog-article-title {
+      color: #111827;
+      font-weight: 700;
+      font-size: clamp(1.65rem, 1rem + 2vw, 2.4rem);
+      line-height: 1.35;
+      letter-spacing: 0.01em;
+      text-align: center;
+      margin: 0.5rem 0 1.5rem;
+    }
+
     .blog-meta {
-      display: grid;
-      grid-template-columns: 7rem 1fr;
-      column-gap: 1.75rem;
-      row-gap: 0;
-      margin: 0 0 2rem;
-      padding: 0.5rem 1.75rem;
-      background: #fafafa;
-      border-radius: 10px;
-    }
-
-    .blog-meta dt,
-    .blog-meta dd {
-      margin: 0;
-      padding: 0.85rem 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.25rem 2.5rem;
+      margin: 0 0 2.25rem;
+      padding: 1.1rem 0;
+      border-top: 1px solid #ececec;
       border-bottom: 1px solid #ececec;
-      font-size: 0.98rem;
-      line-height: 1.5;
     }
 
-    .blog-meta dt {
-      color: #6b7280;
+    .blog-meta-item {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+    }
+
+    .blog-meta-label {
+      color: #9ca3af;
+      font-size: 0.78rem;
       font-weight: 500;
-      letter-spacing: 0.02em;
+      margin-bottom: 0.2rem;
     }
 
-    .blog-meta dd {
+    .blog-meta-value {
       color: #1f2937;
+      font-size: 1rem;
       font-weight: 600;
+      line-height: 1.5;
+      word-break: break-word;
     }
 
-    .blog-meta dt:last-of-type,
-    .blog-meta dd:last-of-type {
-      border-bottom: none;
+    .blog-images {
+      margin: 0 -0.75rem 2.5rem;
+    }
+
+    .blog-image {
+      border-radius: 6px;
+    }
+
+    .blog-description-wrapper {
+      margin-top: 1rem;
+    }
+
+    .blog-description {
+      color: #1f2937;
+      font-size: 1.0625rem;
+      line-height: 1.9;
+    }
+
+    .blog-description p {
+      margin: 0 0 1.25em;
+    }
+
+    .blog-description p:last-child {
+      margin-bottom: 0;
+    }
+
+    .article-container {
+      color: #1f2937;
+      font-size: 1.0625rem;
+      line-height: 1.9;
+    }
+
+    .article-container .article-content p {
+      margin: 0 0 1.25em;
     }
 
     @media (max-width: 575px) {
+      .blog-article {
+        padding: 0 0.25rem;
+      }
+
       .blog-meta {
-        grid-template-columns: 1fr;
-        padding: 0.75rem 1.25rem;
+        gap: 1rem 1.5rem;
+        padding: 1rem 0;
       }
 
-      .blog-meta dt {
-        padding: 0.85rem 0 0.1rem;
-        border-bottom: none;
-        font-size: 0.85rem;
-      }
-
-      .blog-meta dd {
-        padding: 0 0 0.85rem;
-      }
-
-      .blog-meta dt:last-of-type {
-        /* keep zero bottom-border behavior */
+      .blog-description {
+        font-size: 1rem;
+        line-height: 1.85;
       }
     }
 
@@ -639,6 +678,8 @@
       display: block;
       width: 100%;
       clear: both;
+      color: #6b7280;
+      font-size: 0.95rem;
     }
   </style>
 </html>


### PR DESCRIPTION
## Summary
A full visual overhaul of the blog detail page and the blog index, replacing the 2000s-style bordered table with modern, paper-card layouts on a soft warm-tinted background.

### blog_post.html
- Replaces the bordered Bootstrap table with a flex strip of label/value meta items inside a white paper card (max-width 1040px) on a `#f7f5f1` page tint with a faint top vignette
- Drops the grey `bg-light shadow-sm` description card; description now sits on white with article-style typography (1.0625rem / line-height 1.9)
- Reorders the article so the description sits **above** the images
- Removes leftover `shadow-lg` and a stray `border: 2px solid green` debug rule on images; muted captions
- Hero trimmed (`pt-5 pb-3 mt-5 mb-2`, section min-height 240px) without clipping the floating ブログ h1; breadcrumb lifted via a non-animated `.blog-breadcrumb-lift` wrapper with a `transform: translateY(-1rem)` (mobile uses container `mt/pt` overrides instead so the h1 anchor moves up too — no gap)
- Tightens `一覧に戻る` spacing

### blog.html
- Same hero treatment as `blog_post.html`
- Wraps the post list in a matching paper card on the same tinted background
- Replaces the `<table>` with a `<ul>` of clickable rows (date · title · arrow grid). Subtle warm hover, arrow fades+slides in on hover, hairlines between rows, stacks single-column under 575px (arrow hidden)
- Inner section heading changed from a redundant 'ブログ' to '投稿一覧'

## Test plan
- [ ] `/blog.html` — confirm hero is no longer over-tall, breadcrumb sits in the gap above the floating ブログ title, and the post list renders as a paper-card with hover/keyboard-focus state on each row
- [ ] Click a post — `/blog_post.html?id=…` shows the white paper card on tinted bg, meta strip with hairline top/bottom borders, description above the images
- [ ] Resize to mobile (≤575px / ≤991px) — breadcrumb stays clear of the fixed header, list rows collapse to single column, meta items wrap cleanly, card padding shrinks
- [ ] Open the article-type post (`?id=20250317` or `20230205`) — meta block is replaced by article HTML on white card without errors
- [ ] Tab-navigate through the list — visible focus state on each row

🤖 Generated with [Claude Code](https://claude.com/claude-code)